### PR TITLE
[Feat] #7 -  AsyncStream을 통한 frame 전달, 이미지 분석 요청 주기 생성

### DIFF
--- a/FFIP-iOS/FFIP-iOS/Sources/Presentation/Camera/CameraModel.swift
+++ b/FFIP-iOS/FFIP-iOS/Sources/Presentation/Camera/CameraModel.swift
@@ -34,7 +34,7 @@ final class CameraModel: NSObject {
     }
     
     private func setupStream() {
-        imageBufferStream = AsyncStream { continuation in
+        imageBufferStream = AsyncStream(bufferingPolicy: .bufferingNewest(1)) { continuation in
             self.continuation = continuation
         }
     }

--- a/FFIP-iOS/FFIP-iOS/Sources/Presentation/Camera/CameraView.swift
+++ b/FFIP-iOS/FFIP-iOS/Sources/Presentation/Camera/CameraView.swift
@@ -12,6 +12,7 @@ struct CameraView: View {
     @Bindable var cameraModel: CameraModel
     
     @State private var frame: CVImageBuffer?
+    @State private var isAnalyzing = false
     
     var body: some View {
         VStack {
@@ -22,9 +23,16 @@ struct CameraView: View {
             
             guard let imageBufferStream = cameraModel.imageBufferStream else { return }
             for await imageBuffer in imageBufferStream {
+                guard !isAnalyzing else { continue }
+                
+                isAnalyzing = true
                 frame = imageBuffer
                 
-                // TODO: 이미지 분석 호출
+                Task {
+                    // TODO: await 이미지 분석 호출
+                    
+                    defer { isAnalyzing = false}
+                }
             }
         }
     }

--- a/FFIP-iOS/FFIP-iOS/Sources/Presentation/Camera/CameraView.swift
+++ b/FFIP-iOS/FFIP-iOS/Sources/Presentation/Camera/CameraView.swift
@@ -11,12 +11,21 @@ struct CameraView: View {
     @Environment(AppCoordinator.self) private var coordinator
     @Bindable var cameraModel: CameraModel
     
+    @State private var frame: CVImageBuffer?
+    
     var body: some View {
         VStack {
-            FrameView(image: cameraModel.frame)
+            FrameView(image: frame)
         }
         .task {
             await cameraModel.start()
+            
+            guard let imageBufferStream = cameraModel.imageBufferStream else { return }
+            for await imageBuffer in imageBufferStream {
+                frame = imageBuffer
+                
+                // TODO: 이미지 분석 호출
+            }
         }
     }
 }


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #7 

## 🔍 PR Content
<!-- 작업 내용 설명 -->
동기적으로 전달되던 CameraModel의 ImageBuffer를 비동기적으로 전달합니다.
CameraView에서 한 번에 한 장의 프레임만의 분석을 요청하게 됩니다.
```
.task {
    await cameraModel.start()
    
    guard let imageBufferStream = cameraModel.imageBufferStream else { return }
    for await imageBuffer in imageBufferStream {
        guard !isAnalyzing else { continue }
        
        isAnalyzing = true
        frame = imageBuffer
        
        Task {
            // TODO: await 이미지 분석 호출
            
            defer { isAnalyzing = false}
        }
    }
}
```

## 📸 Screenshot (UI 작업 시 선택사항)
<!-- 작업 화면의 스크린샷 -->
|    구현 내용    |   SE   |   Mini   |   Pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "" width ="250"> | <img src = "" width ="250"> | <img src = "" width ="250"> |

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->

## ✅ Checklist
- [ ] 필요없는 주석, 프린트문 제거했는지 확인
- [ ] 컨벤션 지켰는지 확인
