### PR TITLE
[Feat] #32 - 텍스트인식 조금 최적화

### DIFF
--- a/FFIP-iOS/FFIP-iOS/Sources/Presentation/Camera/ExactCameraMediator.swift
+++ b/FFIP-iOS/FFIP-iOS/Sources/Presentation/Camera/ExactCameraMediator.swift
@@ -32,6 +32,7 @@ final class ExactCameraMediator: NSObject {
 
     func start() async {
         await cameraModel.start()
+        await visionModel.prepare()
 
         guard let framesStream = cameraModel.framesStream else { return }
         Task {

--- a/FFIP-iOS/FFIP-iOS/Sources/Presentation/Camera/ExactCameraView.swift
+++ b/FFIP-iOS/FFIP-iOS/Sources/Presentation/Camera/ExactCameraView.swift
@@ -41,7 +41,7 @@ struct ExactCameraView: View {
                         FfipBoundingBox(observation: observation)
                     }
                 }
-                .frame(width: screenHeight * 3 / 4, height: screenHeight)
+                .frame(width: screenHeight * 9 / 16, height: screenHeight)
                 .clipped()
             }
             .ignoresSafeArea(.all)

--- a/FFIP-iOS/FFIP-iOS/Sources/Presentation/Camera/SemanticCameraMediator.swift
+++ b/FFIP-iOS/FFIP-iOS/Sources/Presentation/Camera/SemanticCameraMediator.swift
@@ -32,6 +32,7 @@ final class SemanticCameraMediator: NSObject {
 
     func start() async {
         await cameraModel.start()
+        await visionModel.prepare()
 
         guard let framesStream = cameraModel.framesStream else { return }
         Task {

--- a/FFIP-iOS/FFIP-iOS/Sources/Presentation/Camera/SemanticCameraView.swift
+++ b/FFIP-iOS/FFIP-iOS/Sources/Presentation/Camera/SemanticCameraView.swift
@@ -41,7 +41,7 @@ struct SemanticCameraView: View {
                         FfipBoundingBox(observation: observation)
                     }
                 }
-                .frame(width: screenHeight * 3 / 4, height: screenHeight)
+                .frame(width: screenHeight * 9 / 16, height: screenHeight)
                 .clipped()
             }
             .ignoresSafeArea(.all)

--- a/FFIP-iOS/FFIP-iOS/Sources/Presentation/Camera/VisionModel.swift
+++ b/FFIP-iOS/FFIP-iOS/Sources/Presentation/Camera/VisionModel.swift
@@ -28,11 +28,19 @@ final class VisionModel: NSObject {
 }
 
 extension VisionModel {
+    func prepare() async {
+        await visionService.prepareTextRecognition(searchKeyword: searchKeyword)
+    }
+    
     func processFrame(_ buffer: CVImageBuffer) async {
         do {
+            let aestheticScore = try await visionService.calculateAestheticScore(from: buffer)
+            guard aestheticScore > 0 else {
+                return
+            }
+            
             let textRects = try await visionService.performTextRecognition(
-                image: buffer,
-                customWords: searchKeyword
+                image: buffer
             )
 
             self.recognizedTextObservations = textRects

--- a/FFIP-iOS/FFIP-iOS/Sources/Utils/VideoCaptureService.swift
+++ b/FFIP-iOS/FFIP-iOS/Sources/Utils/VideoCaptureService.swift
@@ -32,8 +32,8 @@ actor VideoCaptureService {
             session.addOutput(videoOutput)
         }
 
-        if session.canSetSessionPreset(.photo) {
-            session.sessionPreset = .photo
+        if session.canSetSessionPreset(.hd1920x1080) {
+            session.sessionPreset = .hd1920x1080
         }
 
         if let connection = videoOutput.connection(with: .video) {

--- a/FFIP-iOS/FFIP-iOS/Sources/Utils/VisionService.swift
+++ b/FFIP-iOS/FFIP-iOS/Sources/Utils/VisionService.swift
@@ -8,17 +8,30 @@
 import Vision
 
 actor VisionService {
-    func performTextRecognition(
-        image: CVImageBuffer,
-        customWords: String
-    ) async throws -> [RecognizedTextObservation] {
-        var recognizeTextRequest = RecognizeTextRequest()
+    private var recognizeTextRequest = RecognizeTextRequest()
+    private var aestheticRequest = CalculateImageAestheticsScoresRequest()
+
+    func prepareTextRecognition(searchKeyword: String) {
+        recognizeTextRequest.minimumTextHeightFraction = 0.01
         recognizeTextRequest.automaticallyDetectsLanguage = false
         recognizeTextRequest.recognitionLanguages = [
             Locale.Language(identifier: "ko-KR"),
             Locale.Language(identifier: "en-US")
         ]
-        recognizeTextRequest.customWords.append(customWords)
+        recognizeTextRequest.customWords.append(searchKeyword)
+    }
+
+    func performTextRecognition(
+        image: CVImageBuffer
+    ) async throws -> [RecognizedTextObservation] {
         return try await recognizeTextRequest.perform(on: image)
+    }
+
+    func calculateAestheticScore(from buffer: CVImageBuffer) async throws
+        -> Float {
+        let observation = try await aestheticRequest.perform(on: buffer)
+        let score = observation.overallScore
+
+        return score
     }
 }


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #32 

## 🔍 PR Content
<!-- 작업 내용 설명 -->
-aesthetic score활용해서 흔들리는 프레임은 분석안해요
- VN textRequest 객체를 재사용합니다. 애플 얘네가 내부적으로 어케햇는지 모르겟는데 찾는게 없는 같은 곳을 오래보면 cpu부하가 줄어드는 효과가 있음.
- 해상도를 4k에서 1920으로 내렸어요. cpu차이는 거의없는데, semantic때 메모리 터질까봐.

## 📸 Screenshot (UI 작업 시 선택사항)
<!-- 작업 화면의 스크린샷 -->
|    구현 내용    |   SE   |   Mini   |   Pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "" width ="250"> | <img src = "" width ="250"> | <img src = "" width ="250"> |

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
이래저래 시도해봣는데 내부적으로 기초적인 최적화를 열심히 해놓은 것 같네요.
이제 한계에 가까운 듯합니다.

## ✅ Checklist
- [ ] 필요없는 주석, 프린트문 제거했는지 확인
- [ ] 컨벤션 지켰는지 확인
